### PR TITLE
changed Threads per child to a number that's easy to do the math

### DIFF
--- a/pre_main_global.conf
+++ b/pre_main_global.conf
@@ -1,14 +1,14 @@
 ## In /etc/apache2/conf.d/includes/pre_main_global.conf
 KeepAlive On
 KeepAliveTimeout 2
-MaxKeepAliveRequests 1920
+MaxKeepAliveRequests 2000
 <IfModule mpm_event_module>
     StartServers             3
     MinSpareThreads        150
-    MaxSpareThreads        250
-    ServerLimit            30
-    ThreadsPerChild         64
-    MaxRequestWorkers      1920
+    MaxSpareThreads        300
+    ServerLimit            40
+    ThreadsPerChild         50
+    MaxRequestWorkers      2000
     MaxConnectionsPerChild   0
 </IfModule>
 


### PR DESCRIPTION
Adjusted the Apache conf settings that we've got here to be close, but use a number that's easier to math in your head.

- we do enough with this that people are going to want to change this.
- we don't want to do the math in intervals of 64, 50 is easier