### PR TITLE
ea-php71 local.ini re-enabling opcache validation

### DIFF
--- a/ea-php71
+++ b/ea-php71
@@ -1640,10 +1640,10 @@ ldap.max_links = -1
 ; tab-width: 4
 ; End:
 opcache.enable=1
-opcache.validate_timestamps=0
+;opcache.validate_timestamps=0
 opcache.memory_consumption=32
 opcache.interned_strings_buffer=8
 opcache.max_accelerated_files=7963
-opcache.revalidate_freq=0
+;opcache.revalidate_freq=0
 opcache.fast_shutdown=0
 opcache.enable_cli=1


### PR DESCRIPTION
commenting out:

- `opcache.validate_timestamps`
- `opcache.revalidate_freq`

As those are not things that we want to disable.